### PR TITLE
Optional replacement of double quotes for single quotes 

### DIFF
--- a/kafka.go
+++ b/kafka.go
@@ -117,6 +117,11 @@ func (a *KafkaAdapter) formatMessage(message *router.Message) (*sarama.ProducerM
 	var encoder sarama.Encoder
 	if a.tmpl != nil {
 		var w bytes.Buffer
+		// Needs a better place for this kind of processing.
+		if opt := os.Getenv("KAFKA_REPLACE_DOUBLE_QUOTES"); opt == "true" {
+			message.Data = strings.Replace(message.Data, "\"", "'")
+		}
+
 		if err := a.tmpl.Execute(&w, message); err != nil {
 			return nil, err
 		}

--- a/kafka.go
+++ b/kafka.go
@@ -119,7 +119,7 @@ func (a *KafkaAdapter) formatMessage(message *router.Message) (*sarama.ProducerM
 		var w bytes.Buffer
 		// Needs a better place for this kind of processing.
 		if opt := os.Getenv("KAFKA_REPLACE_DOUBLE_QUOTES"); opt == "true" {
-			message.Data = strings.Replace(message.Data, "\"", "'")
+			message.Data = strings.Replace(message.Data, "\"", "'", -1)
 		}
 
 		if err := a.tmpl.Execute(&w, message); err != nil {


### PR DESCRIPTION
Gives the option to the user, via an environmental variable [KAFKA_REPLACE_DOUBLE_QUOTES], to replace double quotes for single quotes. This allows the template used in KAFKA_TEMPLATE to be able to generate a valid JSON output that can be used by log aggregators. 
