### PR TITLE
Support accessing environment variables in template

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ Hello World
 time="2015-06-23 09:54:55.241951004 +0000 UTC" container_name="/hello_container" source="stdout" data="Hello World"
 ```
 
+### environment variable support
+
+The adapter supports extracting environment variable values using the included `getenv` template function.
+
+Example:
+
+```
+KAFKA_TEMPLATE="myvar=\"{{getenv .Container.Config.Env 'MY_ENV_VAR'}}\""
+```
+
 ## route configuration
 
 If you've mounted a volume to `/mnt/routes`, then consider pre-populating your routes. The following script configures a route to send standard messages from a "cat" container to one Kafka topic, and a route to send standard/error messages from a "dog" container to another topic.

--- a/kafka.go
+++ b/kafka.go
@@ -40,7 +40,10 @@ func NewKafkaAdapter(route *router.Route) (router.LogAdapter, error) {
 	var err error
 	var tmpl *template.Template
 	if text := os.Getenv("KAFKA_TEMPLATE"); text != "" {
-		tmpl, err = template.New("kafka").Parse(text)
+		funcMap := template.FuncMap{
+			"getenv": tplGetEnvVar,
+		}
+		tmpl, err = template.New("kafka").Funcs(funcMap).Parse(text)
 		if err != nil {
 			return nil, errorf("Couldn't parse Kafka message template. %v", err)
 		}
@@ -150,6 +153,16 @@ func readTopic(address string, options map[string]string) string {
 	}
 
 	return topic
+}
+
+func tplGetEnvVar(env []string, key string) string {
+	key_equals := key + "="
+	for _, value := range env {
+		if strings.HasPrefix(value, key_equals) {
+			return value[len(key_equals):]
+		}
+	}
+	return ""
 }
 
 func errorf(format string, a ...interface{}) (err error) {


### PR DESCRIPTION
If one want's to get information from a container's environment variable e.g. `.Container.Config.Env`, there is no easy way to do this with Golang text/template.

Create a custom helper function to do this.