### PR TITLE
Add support for TLS certificated-based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ docker run --name logspout \
 
 The routes can be updated on a running container by using the **logspout** [Route API](https://github.com/gliderlabs/logspout/tree/master/routesapi) and specifying the route `id` "cat" or "dog".
 
+## TLS Authentication Support
+Some brokers require TLS certificate-based authentication.  This adapter supports this if you provide both a certificate and a private key file in the container.  
+
+To use this, mount certificate and private key files (in PEM format) into the container, then set the *TLS_CERT_FILE* and *TLS_PRIVKEY_FILE* environment variables to point to their location on the disk **inside the container**, like so:
+
+```
+docker run --name logspout \
+-p "8000:8000" \
+--volume /logspout/routes:/mnt/routes \
+--volume /var/run/docker.sock:/tmp/docker.sock \
+--volume /logspout/tls:/mnt/tls \
+-e "TLS_CERTFILE=/mnt/tls/cert.pem" \
+-e "TLS_PRIVKEY_FILE=/mnt/tls/priv.key"
+```
 ## build
 
 **logspout-kafka** is a custom **logspout** module. To use it, create an empty `Dockerfile` based on `gliderlabs/logspout` and include this **logspout-kafka** module in a new `modules.go` file.

--- a/kafka.go
+++ b/kafka.go
@@ -45,12 +45,16 @@ func NewKafkaAdapter(route *router.Route) (router.LogAdapter, error) {
 
 	keypair, err := tls.X509KeyPair([]byte(tls_cert), []byte(tls_privkey))
 	if err != nil {
-		return nul, error("Couldn't establish TLS authentication keypair. Check TLS_CERT and TLS_PRIVKEY environment vars.")
+		return nil, errorf("Couldn't establish TLS authentication keypair. Check TLS_CERT and TLS_PRIVKEY environment vars.")
 	}
 
-  tls_configuration := &tls.Config{
+  tls_configuration, err := &tls.Config{
 		Certificates:	[]tls.Certificate{keypair},
 		InsecureSkipVerify: false,
+	}
+
+	if err != nil {
+		return nil, errorf("Couldn't build TLS configuration. Bad TLS_CERT and/or TLS_PRIVKEY variables?")
 	}
 
 	var tmpl *template.Template

--- a/kafka.go
+++ b/kafka.go
@@ -99,9 +99,7 @@ func NewKafkaAdapter(route *router.Route) (router.LogAdapter, error) {
 	}
   config := newConfig()
 	if (cert_file != "") && (key_file != "") {
-		if os.Getenv("DEBUG") != "" {
-			log.Println("Enabling TLS support.")
-		}
+		log.Println("Enabling Kafka TLS support.")
 		config.Net.TLS.Config = tls_configuration
 		config.Net.TLS.Enable = true
 	}

--- a/kafka.go
+++ b/kafka.go
@@ -71,7 +71,7 @@ func NewKafkaAdapter(route *router.Route) (router.LogAdapter, error) {
 
   tls_configuration := &tls.Config{
 		Certificates:	[]tls.Certificate{keypair},
-		InsecureSkipVerify: false,
+		InsecureSkipVerify: true,
 	}
 
 	var tmpl *template.Template

--- a/kafka.go
+++ b/kafka.go
@@ -94,6 +94,9 @@ func NewKafkaAdapter(route *router.Route) (router.LogAdapter, error) {
 
 	var producer sarama.AsyncProducer
 
+	if os.Getenv("DEBUG") != "" {
+		log.Println("Generating Kafka configuration.")
+	}
   config := newConfig()
 	if (cert_file != "") && (key_file != "") {
 		if os.Getenv("DEBUG") != "" {

--- a/kafka.go
+++ b/kafka.go
@@ -98,10 +98,14 @@ func NewKafkaAdapter(route *router.Route) (router.LogAdapter, error) {
 		log.Println("Generating Kafka configuration.")
 	}
   config := newConfig()
-	log.Println("Enabling Kafka TLS support.")
-	config.Net.TLS.Config = tls_configuration
-	config.Net.TLS.Enable = true
 
+	if (cert_file != "") && (key_file != "") {
+		if os.Getenv("DEBUG") != "" {
+			log.Println("Enabling Kafka TLS support.")
+		}
+		config.Net.TLS.Config = tls_configuration
+		config.Net.TLS.Enable = true
+	}
 
 	for i := 0; i < retries; i++ {
 

--- a/kafka.go
+++ b/kafka.go
@@ -98,11 +98,10 @@ func NewKafkaAdapter(route *router.Route) (router.LogAdapter, error) {
 		log.Println("Generating Kafka configuration.")
 	}
   config := newConfig()
-	if (cert_file != "") && (key_file != "") {
-		log.Println("Enabling Kafka TLS support.")
-		config.Net.TLS.Config = tls_configuration
-		config.Net.TLS.Enable = true
-	}
+	log.Println("Enabling Kafka TLS support.")
+	config.Net.TLS.Config = tls_configuration
+	config.Net.TLS.Enable = true
+
 
 	for i := 0; i < retries; i++ {
 

--- a/kafka.go
+++ b/kafka.go
@@ -44,30 +44,6 @@ func NewKafkaAdapter(route *router.Route) (router.LogAdapter, error) {
 	cert_file := os.Getenv("TLS_CERT_FILE")
 	key_file := os.Getenv("TLS_PRIVKEY_FILE")
 
-  if cert_file != "" {
-		certfile, err := os.Open(cert_file)
-		if err != nil {
-			return nil, errorf("Couldn't open TLS certificate file: %s", err)
-		}
-
-		tls_cert, err := ioutil.ReadAll(certfile)
-		if err != nil {
-			return nil, errorf("Couldn't read TLS certificate: %s", err)
-		}
-	}
-
-	if key_file != "" {
-		keyfile, err := os.Open(key_file)
-		if err != nil {
-			return nil, errorf("Couldn't open TLS private key file: %s", err)
-		}
-
-		tls_privkey, err := ioutil.ReadAll(keyfile)
-		if err != nil {
-			return nil, errorf("Couldn't read TLS private key: %s", err)
-		}
-	}
-
 	var tmpl *template.Template
 	if text := os.Getenv("KAFKA_TEMPLATE"); text != "" {
 		tmpl, err = template.New("kafka").Parse(text)
@@ -96,6 +72,26 @@ func NewKafkaAdapter(route *router.Route) (router.LogAdapter, error) {
 	if (cert_file != "") && (key_file != "") {
 		if os.Getenv("DEBUG") != "" {
 			log.Println("Enabling Kafka TLS support.")
+		}
+
+		certfile, err := os.Open(cert_file)
+		if err != nil {
+			return nil, errorf("Couldn't open TLS certificate file: %s", err)
+		}
+
+		keyfile, err := os.Open(key_file)
+		if err != nil {
+			return nil, errorf("Couldn't open TLS private key file: %s", err)
+		}
+
+		tls_cert, err := ioutil.ReadAll(certfile)
+		if err != nil {
+			return nil, errorf("Couldn't read TLS certificate: %s", err)
+		}
+
+		tls_privkey, err := ioutil.ReadAll(keyfile)
+		if err != nil {
+			return nil, errorf("Couldn't read TLS private key: %s", err)
 		}
 
 		keypair, err := tls.X509KeyPair([]byte(tls_cert), []byte(tls_privkey))


### PR DESCRIPTION
Hello.  I've been working with a broker requires certificate-based authentication.  Since I otherwise think your Kafka support is great, I forked it and added support for this type of authentication to the code.  You can see the new section of the README.md for full details, but in short if you provide TLS_CERT_FILE and TLS_PRIVKEY_FILE env variables that point to the locations of the correct files in the image, it will read them and use them for authentication.  If you don't provide both values, though, everything acts as before and no special TLS processing takes place.  